### PR TITLE
add missing function param

### DIFF
--- a/src/openziti/__main__.py
+++ b/src/openziti/__main__.py
@@ -15,7 +15,7 @@
 from . import zitilib
 
 
-def do_enroll():
+def do_enroll(args):
     with open(args.jwt) as jwt_file:  # pylint: disable=unspecified-encoding
         jwt = jwt_file.read()
 


### PR DESCRIPTION
```bash
 ❯ python -m openziti enroll --jwt=/tmp/pyclient1.jwt --identity=/opt/openziti/etc/identities/zeds-kentest1-pyclient1.json
Traceback (most recent call last):
  File "/home/kbingham/.pyenv/versions/3.7.0/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/kbingham/.pyenv/versions/3.7.0/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/kbingham/Sites/netfoundry/github/ziti-sdk-py/src/openziti/__main__.py", line 45, in <module>
    args.func(args)
TypeError: do_enroll() takes 0 positional arguments but 1 was given
```