### PR TITLE
normalize binding addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ Or try our decorator pattern with a function annotation
 @openziti.zitify(bindings={('127.0.0.1', 18080): {'ztx': '/path/to/identity.json', 'service': 'name-of-ziti-service'}})
 def yourFunction():
 ```
+
+The `binding` dictionary configures what happens when the code tries to open a server socket. Standard network addresses 
+are mapped to ziti service configurations. For example, with his configuration
+```python
+bindings = {
+   ('0.0.0.0', 8080): { 'ztx': 'my-identity.json', 'service':'my-service' }
+}
+```
+when application opens a server socket and binds to address `0.0.0.0:8080` it will actually bind to the ziti service named `my-service`.
+
+Binding addresses can be specified with tuples, strings, or ints(ports). `('0.0.0.0', 8080)`, `'0.0.0.0:8080'`, `':8080'`, `8080` 
+are all considered and treated the same.
+
 ## Examples
 Try it out yourself with one of our [examples](sample%2FREADME.md)
 * [Flazk](sample/flask-of-ziti)

--- a/sample/flask-of-ziti/helloFlazk.py
+++ b/sample/flask-of-ziti/helloFlazk.py
@@ -1,4 +1,4 @@
-#  Copyright NetFoundry Inc.
+#  Copyright (c)  NetFoundry Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -21,20 +21,16 @@ bind_opts = {}  # populated in main
 
 
 @openziti.zitify(bindings={
-    ('127.0.0.1', 18080): bind_opts
+    ':18080': bind_opts,
 })
 def runApp():
     from waitress import serve
-    serve(app,host='127.0.0.1',port=18080)
+    serve(app,port=18080)
 
 
 @app.route('/')
 def hello_world():  # put application's code here
     return 'Have some Ziti!'
-
-@app.route('/json')
-def get_json():
-    return '{ "name":"Ziti", "message":"Have some JSON Ziti"}'
 
 
 if __name__ == '__main__':

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,4 +38,4 @@ tag_prefix = v
 parentdir_prefix = openziti-
 
 [openziti]
-ziti_sdk_version = 0.32.2
+ziti_sdk_version = 0.32.3

--- a/tests/util_tests.py
+++ b/tests/util_tests.py
@@ -1,0 +1,39 @@
+#  Copyright (c)  NetFoundry Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import unittest
+
+
+class TestZitiModule(unittest.TestCase):
+    def test_normalize_addresses(self):
+        from openziti.zitisock import process_bindings
+        orig = {
+            ('localhost', 8080): "address1",
+            ('localhost', '8081'): "address2",
+            ('', 8082): "address3",
+            'localhost:8083': "address4",
+            ':8084': "address5",
+            8085: "address6",
+        }
+
+        expected = {
+            ('localhost', 8080): "address1",
+            ('localhost', 8081): "address2",
+            ('0.0.0.0', 8082): "address3",
+            ('localhost', 8083): "address4",
+            ('0.0.0.0', 8084): "address5",
+            ('0.0.0.0', 8085): "address6",
+        }
+
+        norm = process_bindings(orig)
+        self.assertEquals(norm, expected)


### PR DESCRIPTION
- allow more flexible configuration of bindings
- update ziti-sdk

Binding addresses can be specified via tuple, string, or int, such as the following binding addresses are considered the same:
- `('0.0.0.0', 1080)`
- `('', 1080)`
- `'0.0.0.0:1080'`
- `':1080`'
- `1080`


fixes #44 