### PR TITLE
update ziti-sdk@0.35.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,4 +38,4 @@ tag_prefix = v
 parentdir_prefix = openziti-
 
 [openziti]
-ziti_sdk_version = 0.34.4
+ziti_sdk_version = 0.35.1


### PR DESCRIPTION
- eliminates the hang when loading identity without any services
- allow service resolution using service name (without intercepts)