### PR TITLE
fixes: async http, decorator usage

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -6,6 +6,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: 'build-wheels-${{ github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   build_wheels:
     strategy:
@@ -34,6 +38,7 @@ jobs:
       - name: Install ziti and run integration tests
         shell: bash
         env:
+          ZITI_LOG: 4
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pip install -r tests/requirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,4 +38,4 @@ tag_prefix = v
 parentdir_prefix = openziti-
 
 [openziti]
-ziti_sdk_version = 1.7.2
+ziti_sdk_version = 1.7.8

--- a/src/openziti/decor.py
+++ b/src/openziti/decor.py
@@ -77,6 +77,7 @@ def zitify(**zkwargs):
     def zitify_func(func):
         def zitified(*args, **kwargs):
             with MonkeyPatch(**zkwargs):
-                func(*args, **kwargs)
+                r = func(*args, **kwargs)
+                return r
         return zitified
     return zitify_func

--- a/src/openziti/zitisock.py
+++ b/src/openziti/zitisock.py
@@ -124,7 +124,7 @@ class ZitiSocket(PySocket):
 
     def accept(self):
         fd, peer = zitilib.accept(self.fileno())
-        return ZitiSocket(af=self._ziti_af, type=self._ziti_type, fileno=fd), peer
+        return ZitiSocket(family=self._ziti_af, type=self._ziti_type, fileno=fd), peer
 
     def setsockopt(self, __level: int, __optname: int, __value: Union[int, bytes]) -> None:
         try:


### PR DESCRIPTION
- make sure to return zitify()-ed function result
- fix: ziti socket constructor parameter mismatch
- fix: async IO needs getpeername()
- update ziti-sdk@1.7.8: support `http_proxy` env variable

[fixes #79]