### PR TITLE
Trusted publishing

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: 'build-wheels-${{ github.ref }}'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -74,8 +74,6 @@ jobs:
       - name: Publish wheels (TestPYPI)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
           packages-dir: dist
           skip-existing: true

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -84,7 +84,5 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: dist
           verbose: true


### PR DESCRIPTION
take advantage of Github -> PyPI/TestPyPI [trusted publishing](https://docs.pypi.org/trusted-publishers/)