### PR TITLE
Use load context with timeout

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,4 +37,4 @@ tag_prefix = v
 parentdir_prefix = openziti-
 
 [openziti]
-ziti_sdk_version = 1.8.3
+ziti_sdk_version = 1.9.1

--- a/src/openziti/context.py
+++ b/src/openziti/context.py
@@ -65,18 +65,19 @@ class ZitiContext:
         return sock
 
     @classmethod
-    def from_path(cls, path) -> tuple["ZitiContext", int]:
+    def from_path(cls, path, timeout=0) -> tuple["ZitiContext", int]:
         """
         Load Ziti Identity
 
         :param path: path to Ziti Identity file
+        :param timeout: timeout in milliseconds for loading identity
         :return: ZitiContext representing given identity
         """
         if not isinstance(path, str):
             raise TypeError("path must be a string")
         if not (isfile(path) or isdir(path)):
             raise ValueError(f"{path} is not a valid path")
-        zh, err = zitilib.load(path)
+        zh, err = zitilib.load(path, timeout)
         if err != 0:
             logging.warning("Failed to load Ziti Identity from %s: %s", path, zitilib.errorstr(err))
         return cls(zh), err
@@ -98,20 +99,21 @@ class ZitiContext:
         return zitilib.wait_for_auth(self._ctx, timeout)
 
 
-def load_identity(path) -> tuple[ZitiContext, int]:
+def load_identity(path, timeout=0) -> tuple[ZitiContext, int]:
     """
     Load Ziti Identity
 
     :param path: path to Ziti Identity file
+    :param timeout: timeout in milliseconds for loading identity
     :return: Ziti Context object representing Ziti Identity
     """
-    return ZitiContext.from_path(path)
+    return ZitiContext.from_path(path, timeout)
 
 
-def get_context(ztx) -> ZitiContext:
+def get_context(ztx, timeout=0) -> ZitiContext:
     if isinstance(ztx, ZitiContext):
         return ztx
     if isinstance(ztx, str):
-        z, _ = ZitiContext.from_path(ztx)
+        z, _ = ZitiContext.from_path(ztx, timeout)
         return z
     raise TypeError(f'{ztx} is not a ZitiContext or str instance')

--- a/src/openziti/zitilib.py
+++ b/src/openziti/zitilib.py
@@ -131,10 +131,11 @@ _ziti_errorstr = ziti.ziti_errorstr
 _ziti_errorstr.argtypes = [ctypes.c_int]
 _ziti_errorstr.restype = ctypes.c_char_p
 
-_load_ctx = ziti.Ziti_load_context
+_load_ctx = ziti.Ziti_load_context_with_timeout
 _load_ctx.argtypes = [
     ctypes.POINTER(ctypes.c_int32), # ziti context handle
     ctypes.POINTER(ctypes.c_char), # ziti identity path or json
+    ctypes.c_int, # ziti timeout in ms
 ]
 _load_ctx.restype = ctypes.c_int
 
@@ -270,12 +271,12 @@ def shutdown():
     ziti.Ziti_lib_shutdown()
 
 
-def load(path) -> tuple[int, int]:
+def load(path, timeout=0) -> tuple[int, int]:
     init()
     b_obj = bytes(path, encoding="utf-8")
     hp = ctypes.c_int32()
 
-    err = _load_ctx(ctypes.pointer(hp), b_obj)
+    err = _load_ctx(ctypes.pointer(hp), b_obj, ctypes.c_int(timeout))
     return hp.value, err
 
 def login_external(ziti_ctx: int, name: str) -> str:

--- a/src/openziti/zitisock.py
+++ b/src/openziti/zitisock.py
@@ -94,7 +94,7 @@ class ZitiSocket(PySocket):
         h, p = addr
         cfg = self._ziti_bindings.get((h, int(p)))
         if cfg is not None:
-            ztx = context.get_context(cfg['ztx'])
+            ztx = context.get_context(cfg['ztx'], timeout=cfg.get('timeout', 0))
             service = cfg['service']
             terminator = None
             if isinstance(service, tuple):


### PR DESCRIPTION
### Add timeout to load context

**Summary**

As [ziti-idk-c ](https://github.com/openziti/ziti-sdk-c/pull/914) now supports specifying a timeout to load an OpenZiti context, a related change was made to use corresponding method in Python SDK.

**Details**
Timeout argument is optional, so `openziti.load(...)` can be used as before.
Currently ziti-sdk-c hasn't release a new version with changes, so this PR is blocked until version 1.9.1 will appear.

To set timeout the proposal is to introduce new optional key `timeout` to bindings:
```
bindings = {
   ('0.0.0.0', 8080): { 'ztx': 'my-identity.json', 'service':'my-service', 'timeout': 1000 }
}
```

Unfortunately https://netfoundry.io/docs/openziti/policies/CONTRIBUTING.html right now returns "Page not found", so I can't proceed with signing CLA